### PR TITLE
Fix Joypad 2

### DIFF
--- a/src/nes/Memory.js
+++ b/src/nes/Memory.js
@@ -96,7 +96,8 @@ export default class Memory {
 								break;
 							case 0x4016: // input
 							case 0x4017:
-								this.mainboard.inputdevicebus.writeToRegister(offset, data);
+								this.mainboard.inputdevicebus.writeToRegister(0x4016, data);
+								this.mainboard.inputdevicebus.writeToRegister(0x4017, data);
 								break;
 						}
 						// APU (write input 4016 + 4017 to APU as well) <-- is that right??

--- a/src/nes/controls/InputDeviceBus.js
+++ b/src/nes/controls/InputDeviceBus.js
@@ -2,42 +2,32 @@ import Joypad from './Joypad';
 
 export default class InputDeviceBus {
   constructor() {
-    this.j1 = new Joypad();
-    this.j2 = new Joypad();
+    this.joyPads = {
+      0x4016: new Joypad(),
+      0x4017: new Joypad(),
+    };
   }
 
   getJoypad(index) {
-    switch (index) {
-      case 0:
-        return this.j1;
-      case 1:
-        return this.j2;
-      default:
-        return null;
-    }
+    return this.joyPads[Object.keys(this.joyPads)[index]];
   }
 
   writeToRegister(offset, data) {
-    switch (offset) {
-      case 0x4016:
-        this.j1.writeToRegister(offset, data);
-        break;
-      case 0x4017:
-        this.j2.writeToRegister(offset, data);
-        break;
+    const pad = this.joyPads[offset];
+
+    if (pad) {
+      pad.writeToRegister(data);
     }
   }
 
   readFromRegister(offset) {
-    var ret = 0;
-    switch (offset) {
-      case 0x4016:
-        ret = this.j1.readFromRegister(offset) | 0;
-        break;
-      case 0x4017:
-        ret = this.j2.readFromRegister(offset) | 0;
-        break;
+    let registerValue = 0;
+    const pad = this.joyPads[offset];
+
+    if (pad) {
+      registerValue = pad.readFromRegister() | 0;
     }
-    return ret;
+
+    return registerValue;
   }
 }

--- a/src/nes/controls/Joypad.js
+++ b/src/nes/controls/Joypad.js
@@ -7,7 +7,7 @@ export default class Joypad {
   }
 
 
-  writeToRegister(offset, data) {
+  writeToRegister(data) {
     const firstBit = data & 1;
     if (this._strobeByte === 1 || firstBit === 1) {
       this._strobeByte = firstBit | 0;
@@ -16,7 +16,7 @@ export default class Joypad {
     }
   }
 
-  readFromRegister(offset) {
+  readFromRegister() {
 
     var ret = 0;
     if (this._strobeByte === 1) {


### PR DESCRIPTION
Fixes #12 - This enables Player 2 joypad functionality

P2 joypad was not being strobed correctly, so it was never reporting the correct memory values (the buttons were being written to memory, but not being read).